### PR TITLE
Bewerted Version

### DIFF
--- a/ModSim_WS1718_Uebung_03.ipynb
+++ b/ModSim_WS1718_Uebung_03.ipynb
@@ -139,7 +139,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Es gibt als Wahrheitswert \"False\" an, da dieselbe zahl im Floatformat verschieden repräsentiert werden kann und das dann nicht dieselbe Ausgangszahl ergibt."
+    "Es gibt als Wahrheitswert \"False\" an, da dieselbe zahl im Floatformat verschieden repräsentiert werden kann und das dann nicht dieselbe Ausgangszahl ergibt. # sehen Commit nachricht"
    ]
   }
  ],


### PR DESCRIPTION
Af3. 'Float Format verschieden repräsentiert werden kann und das nicht automatisch die selbe Ausgangszahl ergibt...' Stimmt fast... eingentlich ergibt sich immer die selbe Ausgangszahl aber nur nicht die richtige. (-2)